### PR TITLE
COR-3894: support btle permission

### DIFF
--- a/Src/Config.cs
+++ b/Src/Config.cs
@@ -76,6 +76,7 @@
         public const int HeadsetConnectingTimeout = 102;
         public const int HeadsetDataTimeOut       = 103;
         public const int HeadsetConnected         = 104;
+        public const int BTLEPermissionNotGranted = 31;
     }
 
     public static class DevStreamParams

--- a/Src/CortexClient.cs
+++ b/Src/CortexClient.cs
@@ -104,6 +104,8 @@ namespace EmotivUnityPlugin
         public event EventHandler<string> SessionClosedNotify;
         public event EventHandler<string> RefreshTokenOK;
 
+        public event EventHandler<bool> BTLEPermissionGrantedNotify; // notify btle permision grant status
+
         private CortexClient()
         {
             
@@ -241,6 +243,15 @@ namespace EmotivUnityPlugin
                     // handle response
                     JToken data = response["result"];
                     HandleResponse(method, data);
+                    // check bluetooth permisison granted
+                    if (method == "queryHeadsets" && response.ContainsKey("attention")) {
+                        JObject attentionObj =  (JObject)response["attention"];
+                        bool btlePermisionGranted = true;
+                        if ((int)attentionObj["code"] == WarningCode.BTLEPermissionNotGranted) {
+                            btlePermisionGranted = false;
+                        }
+                        BTLEPermissionGrantedNotify(this, btlePermisionGranted);
+                    }
                 }
             }
             else if (response["sid"] != null)

--- a/Src/DataStreamManager.cs
+++ b/Src/DataStreamManager.cs
@@ -73,6 +73,12 @@ namespace EmotivUnityPlugin
         public event EventHandler<string> SysEventSubscribed;
         public event EventHandler<string> SysEventUnSubscribed;
 
+        public event EventHandler<bool> BTLEPermissionGrantedNotify
+        {
+            add { _dsProcess.BTLEPermissionGrantedNotify += value; }
+            remove { _dsProcess.BTLEPermissionGrantedNotify -= value; }
+        }
+
         private DataStreamManager()
         {
             Init();

--- a/Src/DataStreamProcess.cs
+++ b/Src/DataStreamProcess.cs
@@ -60,6 +60,12 @@ namespace EmotivUnityPlugin
         // For test
         public event EventHandler<string> ErrorNotify;
 
+        public event EventHandler<bool> BTLEPermissionGrantedNotify
+        {
+            add { _ctxClient.BTLEPermissionGrantedNotify += value; }
+            remove { _ctxClient.BTLEPermissionGrantedNotify -= value; }
+        }
+
         /// <summary>
         /// Gets states when work with cortex.
         /// Currently, the states relate to authorizing.


### PR DESCRIPTION
The PR will support to parse BTLE permission information in queryHeadsets. The requirement is only  applied from MacOS11 to guide user grant BTLE permission for Emotiv's apps. 
Please help to review. Thanks