### PR TITLE
Easier access to mental commands

### DIFF
--- a/Src/EmotivUnityItf.cs
+++ b/Src/EmotivUnityItf.cs
@@ -41,7 +41,11 @@ namespace EmotivUnityPlugin
         public string TrainingLog { get => _trainingLog; set => _trainingLog = value; }
         public string MessageLog { get => _messageLog; set => _messageLog = value; }
 
-
+        public class MentalComm{
+            public string act = "NULL";
+            public double pow = 0;
+        }
+        public MentalComm LatestMentalCommand { get; private set; } = new MentalComm();
 
         /// <summary>
         /// Set up App configuration.
@@ -580,6 +584,8 @@ namespace EmotivUnityPlugin
             string dataText = "com data: " + data.Act + ", power: " + data.Pow.ToString() + ", time " + data.Time.ToString();
             // print out data to console
             UnityEngine.Debug.Log(dataText);
+            LatestMentalCommand.act = data.Act;
+            LatestMentalCommand.pow = data.Pow;
         }
 
         private void OnFacialExpReceived(object sender, FacEventArgs data)


### PR DESCRIPTION
Hi I was recently developing a Unity game using the Emotiv API, but found it very confusing on how to get the mental commands, so I did this modification where I basically created a public property to get the latest mental command and it seems to work, well it at least made it easier for me to get up and running with getting mental commands directly to my Unity game.

Hopefully you guys like this, and please let me know if there's already another way to do this way, that's easier I'd appreciate to know more about it. Thanks