### PR TITLE
COR-5639: update init functions and remove obsoleted code

### DIFF
--- a/Src/Authorizer.cs
+++ b/Src/Authorizer.cs
@@ -216,12 +216,7 @@ namespace EmotivUnityPlugin
                     _cortexToken        = cortexToken;
                 }
 
-                // do not save token for mobile platform
-                #if !UNITY_ANDROID && !UNITY_IOS && !USE_EMBEDDED_LIB
-                    UnityEngine.Debug.Log("Save token for next using.");
-                    // Save App version
-                    Utils.SaveAppVersion(Config.AppVersion);
-                #endif
+                // save token for next using
                 Authorizer.SaveToken(tokenInfo);
 
                 // get license information
@@ -315,10 +310,10 @@ namespace EmotivUnityPlugin
 
         private static string GetSavedTokenFilePath()
         {
-            if (String.IsNullOrEmpty(Utils.DataDirectory)) {
+            if (String.IsNullOrEmpty(Config.DataDirectory)) {
                 return "";
             }
-            string fileDir = Path.Combine(Utils.DataDirectory, Config.TmpDataFileName);
+            string fileDir = Path.Combine(Config.DataDirectory, Config.TmpDataFileName);
             if (!File.Exists(fileDir)) {
                 UnityEngine.Debug.Log("GetSavedTokenFilePath: not exists file " + fileDir);
                 return "";

--- a/Src/BCIGameItf.cs
+++ b/Src/BCIGameItf.cs
@@ -178,10 +178,10 @@ namespace EmotivUnityPlugin
         /// Initialize and start the application. It should be called when the app has granted permissions: bluetooth, location, write external storage.
         /// It will auto login if the user has not logged in before otherwise it will authorize to get cortex token for working with the cortex API.
         /// </summary>
-        public void Start(string clientId, string clientSecret, string appName, string appVersion, bool isSaveLog = true, object context = null)
+        public void Start(string clientId, string clientSecret, string appName, bool isSaveLog = true, object context = null)
         {
             // Init
-            emotivUnityItf.Init(clientId, clientSecret, appName, appVersion, "", isSaveLog);
+            emotivUnityItf.Init(clientId, clientSecret, appName, isSaveLog);
             // Loads the Cortex library, connects, and authorizes the application.
             emotivUnityItf.Start(context);
         }

--- a/Src/Config.cs
+++ b/Src/Config.cs
@@ -1,26 +1,20 @@
-﻿namespace EmotivUnityPlugin
+﻿using System.IO;
+
+namespace EmotivUnityPlugin
 {
     /// <summary>
     /// Contain common Config of a Unity App.
     /// </summary>
     public static class Config
     {
-        
-        /// <summary>ClientId of your application.
-        /// <para>To get a client id and a client secret, you must connect to your Emotiv
-        /// account on emotiv.com and create a Cortex app.
-        /// https://www.emotiv.com/my-account/cortex-apps/.</para></summary>
         public static string AppClientId            = "";
         public static string AppClientSecret        = "";
+        public static string AppUrl = "";
+        public static string AppName = "";
+        public static string ProviderName = "";
+        public static string LogDirectory = "";
+        public static string DataDirectory = "";
 
-        public static string AppUrl                 = "wss://localhost:6868"; // default
-        public static string AppVersion             = "1.0.0"; // default
-        public static string AppName                = "UnityApp"; // default app name
-        
-        /// <summary>
-        /// Name of directory where contain tmp data and logs file.
-        /// </summary>
-        public static string TmpAppDataDir          = "UnityApp";
         public static string EmotivAppsPath         = ""; // location of emotiv Apps . Eg: C:\Program Files\EmotivApps
         public static string TmpVersionFileName     = "version.ini";
         public static string TmpDataFileName        = "data.dat";
@@ -36,6 +30,49 @@
         public static string FlexMapping = @"{
                                   'CMS':'TP8', 'DRL':'P6',
                                   'RM':'TP10','RN':'P4','RO':'P8'}";
+
+        public static void Init(
+            string clientId,
+            string clientSecret,
+            string appName,
+            bool allowSaveLogAndDataToFile,
+            string appUrl,
+            string providerName,
+            string emotivAppsPath
+        )
+        {
+            AppClientId = clientId;
+            AppClientSecret = clientSecret;
+            AppName = appName;
+            AppUrl = appUrl;
+            ProviderName = providerName;
+            EmotivAppsPath = emotivAppsPath;
+
+            if (allowSaveLogAndDataToFile)
+            {
+                // create tmp directory for unity app
+                string tmpPath = Utils.GetAppTmpPath(appName, providerName);
+                LogDirectory = Path.Combine(tmpPath, LogsDir);
+                DataDirectory = Path.Combine(tmpPath, ProfilesDir);
+
+                // Ensure the directories exist
+                if (!Directory.Exists(LogDirectory))
+                {
+                    Directory.CreateDirectory(LogDirectory);
+                }
+
+                if (!Directory.Exists(DataDirectory))
+                {
+                    Directory.CreateDirectory(DataDirectory);
+                }
+            }
+            else
+            {
+                LogDirectory = "";
+                DataDirectory = "";
+            }
+
+        }
     }
 
     public static class DataStreamName

--- a/Src/DataStreamManager.cs
+++ b/Src/DataStreamManager.cs
@@ -577,47 +577,7 @@ namespace EmotivUnityPlugin
         /// </summary>
         public void StartAuthorize(string licenseKey = "", object context = null)
         {
-            if (string.IsNullOrEmpty(Config.AppClientId) || 
-                string.IsNullOrEmpty(Config.AppClientSecret) || 
-                string.IsNullOrEmpty(Config.AppVersion)) {
-                UnityEngine.Debug.Log(" Can not start App because invalid application configuration.");
-                return;
-            }
             _dsProcess.StartAuthorize(licenseKey, context);
-        }
-
-        /// <summary>
-        /// Set up App configuration.
-        /// </summary>
-        /// <param name="clientId">A clientId of Application.</param>
-        /// <param name="clientSecret">A clientSecret of Application.</param>
-        /// <param name="appVersion">Application version.</param>
-        /// <param name="appName">Application name.</param>
-        public void SetAppConfig(string clientId, string clientSecret,
-                                 string appVersion="", string appName="",
-                                 string appUrl = "", string emotivAppsPath = "") 
-        {
-            if (string.IsNullOrEmpty(clientId)) {
-                UnityEngine.Debug.LogError("Empty clientId. Please fill in the clientId before running.");
-                return;
-            }
-            if (string.IsNullOrEmpty(clientSecret))
-            {
-                UnityEngine.Debug.LogError("Empty clientSecret. Please fill in the clientId before running.");
-                return;
-            }
-
-            Config.AppClientId      = clientId;
-            Config.AppClientSecret  = clientSecret;
-
-            if (!string.IsNullOrEmpty(appVersion))
-                Config.AppVersion       = appVersion;
-            if (!string.IsNullOrEmpty(appUrl))
-                Config.AppUrl       = appUrl;
-            if (!string.IsNullOrEmpty(emotivAppsPath))
-                Config.EmotivAppsPath = emotivAppsPath;
-            if (!string.IsNullOrEmpty(appName))
-                Config.AppName = appName;
         }
 
         /// <summary>

--- a/Src/EmotivUnityItf.cs
+++ b/Src/EmotivUnityItf.cs
@@ -171,44 +171,37 @@ namespace EmotivUnityPlugin
         }
 
         /// <summary>
-        /// Sets up the application configuration.
-        /// </summary>
-        /// <param name="clientId">The client ID of the application.</param>
-        /// <param name="clientSecret">The client secret of the application.</param>
-        /// <param name="appVersion">The version of the application.</param>
-        /// <param name="appName">The name of the application.</param>
-        /// <param name="appUrl">The URL of the application (optional). Only for desktop version and work with Cortex Service.</param>
-        /// <param name="emotivAppsPath">The path to Emotiv Launcher file path (optional). Only for desktop version and work with Cortex Service. </param>
-        public void SetAppConfig(string clientId, string clientSecret,
-                                 string appVersion, string appName,
-                                 string appUrl = "", string emotivAppsPath = "")
-        {
-            _dsManager.SetAppConfig(clientId, clientSecret, appVersion, appName, appUrl, emotivAppsPath);
-        }
-
-        /// <summary>
         /// Initializes the Emotiv Unity Interface.
         /// </summary>
         /// <param name="clientId">The client ID of the application.</param>
         /// <param name="clientSecret">The client secret of the application.</param>
-        /// <param name="appName">The name of the application.</param>
-        /// <param name="appVersion">The version of the application (optional).</param>
+        /// <param name="appName">The name of the application. the Appname must not be empty</param>
+        /// <param name="allowSaveLogToFile">Set to true whether to save log and token to file or not.
         /// <param name="isDataBufferUsing"> Set to true whether to use data buffer to store data before get from Unity script. 
         ///                Otherwise, the subscribing data only are handled on xyDataReceived() and displayed on Message Log   </param>
+        /// <param name="appUrl">The URL of the application (optional). Only for desktop version and work with Cortex Service.</param>
+        /// <param name="providerName">The provider name (optional). Used to create a subdirectory in the application data directory.</param>
+        /// <param name="emotivAppsPath">The path to Emotiv Launcher file path (optional). Only for desktop version and work with Cortex Service. </param>
         public void Init(string clientId, string clientSecret, string appName,
-                         string appVersion = "", string appUrl = "", bool allowSaveLogToFile = true, bool isDataBufferUsing = true)
+                         bool allowSaveLogToFile = true, bool isDataBufferUsing = true,
+                         string appUrl = "", string providerName = "", string emotivAppsPath = "")
         {
             if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
             {
                 UnityEngine.Debug.LogError("The clientId or clientSecret is empty. Please fill them before starting.");
                 return;
             }
-            
-            if (allowSaveLogToFile) {
-                // to create log directory and data directory to save token 
-                Utils.Init();
+
+            if (string.IsNullOrEmpty(appName))
+            {
+                UnityEngine.Debug.LogError("The appName is empty. Please fill it before starting.");
+                return;
             }
-            
+
+            // init configuration
+            Config.Init(clientId, clientSecret, appName, allowSaveLogToFile, appUrl, providerName, emotivAppsPath);
+
+            // init logger
             MyLogger.Instance.Init(appName, allowSaveLogToFile);
 
             // init authentication for Android and Embedded Cortex Desktop
@@ -216,7 +209,6 @@ namespace EmotivUnityPlugin
             InitForAuthentication(clientId, clientSecret);
             #endif
 
-            _dsManager.SetAppConfig(clientId, clientSecret, appVersion, appName, appUrl);
             _dsManager.IsDataBufferUsing = isDataBufferUsing;
             // init bcitraining
             _bciTraining.Init();

--- a/Src/MyLogger.cs
+++ b/Src/MyLogger.cs
@@ -44,7 +44,7 @@ namespace EmotivUnityPlugin
                 string dateTimeStr = DateTime.Now.ToString("yyyyMMdd_HHmmss");
                 string fileName = prefixFileName + "Log_" + dateTimeStr + ".txt";
 
-                string logPath = Utils.GetLogPath();
+                string logPath = Config.LogDirectory;
                 string filePath = Path.Combine(logPath, fileName);
                 m_FileStream = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
                 m_StreamWriter = new StreamWriter(m_FileStream);

--- a/Src/Utils.cs
+++ b/Src/Utils.cs
@@ -7,49 +7,6 @@ namespace EmotivUnityPlugin
 {
     public static class Utils
     {
-        
-        private static string _logDirectory;
-        private static string _dataDirectory;
-
-        public static string LogDirectory { get => _logDirectory; set => _logDirectory = value; }
-        public static string DataDirectory { get => _dataDirectory; set => _dataDirectory = value; }
-        
-        // init Utils to create needed directories for unity app. It should be called at Start() and before logger.Init() method
-        public static void Init()
-        {
-            // create tmp directory for unity app
-            string tmpPath = GetAppTmpPath();
-            _logDirectory = Path.Combine(tmpPath, Config.LogsDir);
-            _dataDirectory = Path.Combine(tmpPath, Config.ProfilesDir);
-
-            // Ensure the directories exist
-            // check directory is existed or not to create
-        if (!Directory.Exists(_logDirectory))
-            {
-                try
-                {
-                    Directory.CreateDirectory(_logDirectory);
-                }
-                catch (UnauthorizedAccessException ex)
-                {
-                    UnityEngine.Debug.LogError("Failed to create Log Directory: " + _logDirectory + " - " + ex.Message);
-                    throw;
-                }
-            }
-
-            if (!Directory.Exists(_dataDirectory))
-            {
-                try
-                {
-                    Directory.CreateDirectory(_dataDirectory);
-                }
-                catch (UnauthorizedAccessException ex)
-                {
-                    UnityEngine.Debug.LogError("Failed to create Data Directory: " + _dataDirectory + " - " + ex.Message);
-                    throw;
-                }
-            }
-        }
 
         public static Int64 GetEpochTimeNow()
         {
@@ -63,8 +20,7 @@ namespace EmotivUnityPlugin
             return prefix + "-" + GetEpochTimeNow();
         }
 
-        // keep some tmp data of Unity App
-        public static string GetAppTmpPath() 
+        public static string GetAppTmpPath(string providerName, string appName)
         {
             string homePath = "";
         #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
@@ -83,13 +39,11 @@ namespace EmotivUnityPlugin
         #else
             homePath = Directory.GetCurrentDirectory();
         #endif
-            string targetPath = Path.Combine(homePath, Config.AppName);
-            return targetPath;
-        }
-
-        public static string GetLogPath() 
-        {
-            return _logDirectory;
+            string targetFolderName = appName;
+            if (!string.IsNullOrEmpty(providerName))
+                targetFolderName = Path.Combine(providerName, appName);
+            
+            return Path.Combine(homePath, targetFolderName);
         }
 
         public static DateTime StringToIsoDateTime(string time) {
@@ -154,55 +108,6 @@ namespace EmotivUnityPlugin
             return true;
         #endif
             
-        }
-
-        public static bool IsSameAppVersion(string appVersion){
-            string rootPath = Utils.GetAppTmpPath();
-
-            string targetDir = Path.Combine(rootPath, Config.ProfilesDir);
-            if (!Directory.Exists(targetDir)){
-                UnityEngine.Debug.Log("IsSameAppVersion: not exists directory " + targetDir);
-                return false;
-            }
-            string fileDir = Path.Combine(targetDir, Config.TmpVersionFileName);
-            if (!File.Exists(fileDir)) {
-                UnityEngine.Debug.Log("IsSameAppVersion: not exists file " + fileDir);
-                return false;
-            }
-            string savedAppVer = File.ReadAllText(fileDir);
-            if (savedAppVer == appVersion) {
-                return true;
-            }
-            else {
-                return false;
-            }
-        }
-        // save cortexToken to File
-        public static void SaveAppVersion(string appVersion) {
-            //get tmp Path of App 
-            string rootPath = Utils.GetAppTmpPath();
-
-            string targetDir = Path.Combine(rootPath, Config.ProfilesDir);
-            if (!Directory.Exists(targetDir)) {
-                try
-                {
-                    // create directory
-                    Directory.CreateDirectory(targetDir);
-                    UnityEngine.Debug.Log("SaveAppVersion: create directory " + targetDir);
-                }
-                catch (Exception e)
-                {      
-                    UnityEngine.Debug.Log("Can not create directory: " + targetDir + " : failed: " + e.ToString());
-                    return;
-                }
-                finally {}
-            }
-            string fileDir = Path.Combine(targetDir, Config.TmpVersionFileName);
-
-            using(var fileStream = new FileStream(fileDir, FileMode.Create)) {
-                byte[] dataByte = new UTF8Encoding(true).GetBytes(appVersion);
-                fileStream.Write(dataByte, 0, dataByte.Length);
-            }
         }
 
         public static bool IsNumericType(object o)

--- a/Src/com.cdm.authentication/Runtime/Browser/WindowsSystemBrowser.cs
+++ b/Src/com.cdm.authentication/Runtime/Browser/WindowsSystemBrowser.cs
@@ -2,7 +2,9 @@
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+ #if USE_EMBEDDED_LIB && (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN)
 using IdentityModel.Client;
+#endif
 using UnityEngine;
 
 namespace Cdm.Authentication.Browser


### PR DESCRIPTION
The PR include:
- remove appVersion in input parameter because the appVersion is unused long time ago but haven't removed yet
- recover emotivAppsPath as input parameter because brainviz need it
- Create an Init() function to init data for Config instead of init via DataStreamManager.cs  for suitable place
- Move  logDirectory and dataDirectory memember and function to create log directory and data directory from Utils to Config for suitable place 

Summary, the main changes of this PR to move members or functions to suitable places, remove unused code.