### PR TITLE
COR-5662: change define for dev server and do not support build on ed…

### DIFF
--- a/Src/BCIGameItf.cs
+++ b/Src/BCIGameItf.cs
@@ -155,9 +155,9 @@ namespace EmotivUnityPlugin
             return emotivUnityItf.MentalStateDatas;
         }
 
-        #if USE_EMBEDDED_LIB && (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN)
+        #if USE_EMBEDDED_LIB && UNITY_STANDALONE_WIN && !UNITY_EDITOR
         /// <summary>
-        /// Process callback to handle authorization response from Emotiv Cloud when login. It use for embedded library on Windows.
+        /// Process callback to handle authorization response from Emotiv Cloud when login. It use for embedded library on Windows and not for editor mode.
         /// </summary>
         public  async Task ProcessCallback(string args) {
             await emotivUnityItf.ProcessCallback(args);

--- a/Src/EmbeddedCortexClient.cs
+++ b/Src/EmbeddedCortexClient.cs
@@ -31,15 +31,6 @@ using System.Runtime.InteropServices;
 
 namespace EmotivUnityPlugin
 {
-    // These flags are set in the build profile
-    #if DEVELOPMENT_BUILD
-    // Config client_id/secrets for development
-    #endif
-
-    #if PRODUCTION_BUILD
-    // Config client_id/secrets for production
-    #endif
-
     #if UNITY_ANDROID
     public class CortexLibInterfaceProxy : AndroidJavaProxy
     {
@@ -251,11 +242,9 @@ namespace EmotivUnityPlugin
                 _cortexLibManager.Call("setJavaLogInterface", _cortexLogHandler);
                 // start the cortex lib
                 _cortexLibManager.Call("start", cortexLibInterfaceProxy);
-                #if DEVELOPMENT_BUILD
+                #if DEV_SERVER
                 Debug.Log("Build is Development");
-                #endif
-
-                #if PRODUCTION_BUILD
+                #else
                 Debug.Log("Build is Production");
                 #endif
             }

--- a/Src/EmotivUnityItf.cs
+++ b/Src/EmotivUnityItf.cs
@@ -109,7 +109,7 @@ namespace EmotivUnityPlugin
 
         #endif
 
-        #if USE_EMBEDDED_LIB && (UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN)
+        #if USE_EMBEDDED_LIB && UNITY_STANDALONE_WIN && !UNITY_EDITOR
         public  async Task ProcessCallback(string args)
         {
             await WindowsSystemBrowser.ProcessCallback(args);
@@ -1202,12 +1202,13 @@ namespace EmotivUnityPlugin
         private void InitForAuthentication(string clientId, string clientSecret)
         {
             string server = "";
-            #if DEVELOPMENT_BUILD
+ #if DEV_SERVER
+            UnityEngine.Debug.Log("Development build detected. Using development server.");
             server = "cerebrum-dev.emotivcloud.com";
-            #endif
-            #if PRODUCTION_BUILD
+#else
+            UnityEngine.Debug.Log("Production build detected. Using production server.");
             server = "cerebrum.emotivcloud.com";
-            #endif
+#endif
             string hash = Md5(clientId);
             string prefixRedirectUrl = "emotiv-" + hash;
             string redirectUrl = prefixRedirectUrl + "://authorize";

--- a/Src/RegistryConfig.cs
+++ b/Src/RegistryConfig.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Reflection;
 using System.IO;
-#if NETFRAMEWORK || NET5_0_OR_GREATER
-using Microsoft.Win32;
+#if UNITY_STANDALONE_WIN && NET_4_6
+using Microsoft.Win32; // For registry operations but only supported on Windows with .NET Framework version >= 4.6, not for .NET Standard
 #endif
 using UnityEngine;
 
@@ -17,15 +17,15 @@ namespace EmotivUnityPlugin
 
         public void Configure()
         {
-#if NETFRAMEWORK || NET5_0_OR_GREATER
+#if UNITY_STANDALONE_WIN && NET_4_6
             if (NeedToAddKeys()) AddRegKeys();
 #else
-            Debug.LogWarning("RegistryConfig is only supported on Windows.");
+            Debug.LogWarning("RegistryConfig is only supported on Windows and with .NET Framework version >= 4.6, not for .NET Standard");
 #endif  
         }
 
         private string CustomUriScheme { get; }
-#if NETFRAMEWORK || NET5_0_OR_GREATER
+#if UNITY_STANDALONE_WIN && NET_4_6
         string CustomUriSchemeKeyPath => RootKeyPath + @"\" + CustomUriScheme;
         string CustomUriSchemeKeyValueValue => "URL:" + CustomUriScheme;
         string CommandKeyPath => CustomUriSchemeKeyPath + @"\shell\open\command";


### PR DESCRIPTION
The PR include
- Change to DEV_SERVER to avoid duplicate with development build mode on build setting
- Update Platform scripting symbols because  Microsoft.Win32.Registry only avaible for windows and .net framework from 4.6
- Do not support processcallback for editor to avoid abnormal behavior

Please help to review