### PR TITLE
COR-5684: update example for macos

### DIFF
--- a/Src/CortexApi/EmbeddedCortexClientNative.cs
+++ b/Src/CortexApi/EmbeddedCortexClientNative.cs
@@ -9,20 +9,20 @@
 //------------------------------------------------------------------------------
 
 
-public class EmbeddedCortexClientWin : global::System.IDisposable {
+public class EmbeddedCortexClientNative : global::System.IDisposable {
   private global::System.Runtime.InteropServices.HandleRef swigCPtr;
   protected bool swigCMemOwn;
 
-  internal EmbeddedCortexClientWin(global::System.IntPtr cPtr, bool cMemoryOwn) {
+  internal EmbeddedCortexClientNative(global::System.IntPtr cPtr, bool cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
   }
 
-  internal static global::System.Runtime.InteropServices.HandleRef getCPtr(EmbeddedCortexClientWin obj) {
+  internal static global::System.Runtime.InteropServices.HandleRef getCPtr(EmbeddedCortexClientNative obj) {
     return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
   }
 
-  internal static global::System.Runtime.InteropServices.HandleRef swigRelease(EmbeddedCortexClientWin obj) {
+  internal static global::System.Runtime.InteropServices.HandleRef swigRelease(EmbeddedCortexClientNative obj) {
     if (obj != null) {
       if (!obj.swigCMemOwn)
         throw new global::System.ApplicationException("Cannot release ownership as memory is not owned");
@@ -35,7 +35,7 @@ public class EmbeddedCortexClientWin : global::System.IDisposable {
     }
   }
 
-  ~EmbeddedCortexClientWin() {
+  ~EmbeddedCortexClientNative() {
     Dispose(false);
   }
 
@@ -56,7 +56,7 @@ public class EmbeddedCortexClientWin : global::System.IDisposable {
     }
   }
 
-  public EmbeddedCortexClientWin() : this(EmotivCortexLibPINVOKE.new_CortexClient(), true) {
+  public EmbeddedCortexClientNative() : this(EmotivCortexLibPINVOKE.new_CortexClient(), true) {
   }
 
   public void sendRequest(string message) {

--- a/Src/EmotivUnityItf.cs
+++ b/Src/EmotivUnityItf.cs
@@ -1225,11 +1225,13 @@ namespace EmotivUnityPlugin
             _crossPlatformBrowser = new CrossPlatformBrowser();
             _crossPlatformBrowser.platformBrowsers.Add(RuntimePlatform.WindowsEditor, new WindowsSystemBrowser());
             _crossPlatformBrowser.platformBrowsers.Add(RuntimePlatform.WindowsPlayer, new WindowsSystemBrowser());
+            _crossPlatformBrowser.platformBrowsers.Add(RuntimePlatform.OSXEditor, new DeepLinkBrowser());
+            _crossPlatformBrowser.platformBrowsers.Add(RuntimePlatform.OSXPlayer, new DeepLinkBrowser());
 
             // windows
-            #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
             new RegistryConfig(prefixRedirectUrl).Configure();
-            #endif
+#endif
 
             var configuration = new AuthorizationCodeFlow.Configuration()
             {


### PR DESCRIPTION
The PR include:
- update to support unity example on macos work with embedded lib
- rename the class EmbeddedCortexClientWin by EmbeddedCortexClientNative because now it also support both win and desktop
- update some refactor at [EmbeddedCortexClient.cs](https://github.com/Emotiv/unity-plugin/compare/master...COR-5684-2?expand=1#diff-45fb30d1a4868cb24d11136f33ebca59e61ef402a335fdfbd928f1bf455106c0) , which suggested by copilot , it make the class shorter and avoid duplicate code


Please help to review. thanks